### PR TITLE
ASUIS-550 add appPathFolder prop and helpers

### DIFF
--- a/js/webspark_webdir.js
+++ b/js/webspark_webdir.js
@@ -35,6 +35,7 @@
             profilesPerPage: value.dataset.profilesPerPage,
             doNotDisplayProfiles: value.dataset.doNotDisplayProfiles,
           },
+          appPathFolder: value.dataset.appPathFolder,
         };
 
         webdirUI.initWebDirectory({

--- a/src/WebsparkWebdirHelpers.php
+++ b/src/WebsparkWebdirHelpers.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\webspark_webdir;
+
+/**
+ * Class WebsparkWebdirHelpers.php.
+ */
+class WebsparkWebdirHelpers
+{
+
+  public function getAppPathFolder($component_name)
+  {
+    $module_handler = \Drupal::service('module_handler');
+    $path_module = $module_handler->getModule('webspark_webdir')->getPath();
+    $appPathFolder = base_path() . $path_module . '/node_modules/@asu-design-system/' . $component_name . '/dist';
+    return $appPathFolder;
+  }
+}

--- a/webspark_webdir.module
+++ b/webspark_webdir.module
@@ -5,7 +5,8 @@ use Drupal\block_content\Entity\BlockContent;
 /**
  * Implements hook_preprocess_HOOK()
  */
-function webspark_webdir_preprocess_block__web_directory(&$variables) {
+function webspark_webdir_preprocess_block__web_directory(&$variables)
+{
   if (empty($variables['block'])) {
     return;
   }
@@ -77,6 +78,8 @@ function webspark_webdir_preprocess_block__web_directory(&$variables) {
     $dontDisplayProfiles = $blockContent->field_ids->value;
   }
 
+  $appPathFolder = \Drupal::service('webspark_webdir.helper_functions')->getAppPathFolder('app-webdir-ui');
+
   $markup = <<<HTML
 <div
   class="webdir-container"
@@ -95,6 +98,7 @@ function webspark_webdir_preprocess_block__web_directory(&$variables) {
   data-profiles-per-page="{$profilesPerPage}"
   data-default-sort="{$defaultSort}"
   data-do-not-display-profiles="{$dontDisplayProfiles}"
+  data-app-path-folder="{$appPathFolder}"
 ></div>
 HTML;
 
@@ -103,5 +107,4 @@ HTML;
   ];
 
   $variables['#attached']['library'][] = 'webspark_webdir/search-ui';
-
 }

--- a/webspark_webdir.services.yml
+++ b/webspark_webdir.services.yml
@@ -10,3 +10,5 @@ services:
       - '@messenger'
   webspark_webdir.webdir_api_url:
     class: Drupal\webspark_webdir\WebdirApiUrl
+  webspark_webdir.helper_functions:
+    class: Drupal\webspark_webdir\WebsparkWebdirHelpers


### PR DESCRIPTION
Adds the new `appPathFolder` prop to ensure that even when js aggregation is turned on the React component has a calculated absolute path it can rely on for defining image assets.

For https://asudev.jira.com/browse/ASUIS-550