### PR TITLE
ASUIS-809

### DIFF
--- a/js/employee-type-field.js
+++ b/js/employee-type-field.js
@@ -57,7 +57,8 @@ function convert_dir(data, default_values) {
     var new_element = {};
     new_element.id = element.name;
     new_element.text = element.name;
-    if (default_values.includes(element.name.toString())) {
+    let default_values_array = default_values[0].split(",");
+    if (default_values_array.includes(element.name.toString())) {
       new_element.state = {'selected' : true};
     }
 

--- a/js/expertise-field.js
+++ b/js/expertise-field.js
@@ -57,7 +57,8 @@ function convert_dir(data, default_values) {
     var new_element = {};
     new_element.id = element.name;
     new_element.text = element.name;
-    if (default_values.includes(element.name.toString())) {
+    let default_values_array = default_values[0].split(",");
+    if (default_values_array.includes(element.name.toString())) {
       new_element.state = {'selected' : true};
     }
 


### PR DESCRIPTION
https://asudev.jira.com/browse/ASUIS-809

There was a bug I noticed where the default checkboxes for filter by employee and filter by expertise type weren’t working if more than one item had been checked and then saved. The hidden field still included those values, but the checkboxes themselves were left empty. So, this PR includes that fix, since the actual issue for the Jira ticket had already been fixed elsewhere.